### PR TITLE
add DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# MacOS
+.DS_Store
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
Added DS_Store to gitignore file. Ignores some MacOS stuff from being auto loaded into the repo.